### PR TITLE
Add support for ratatui 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["cli", "console", "ratatui", "terminal", "tui"]
 derive_builder = "0.12.0"
 font8x8 = "0.3.1"
 itertools = "0.11.0"
-ratatui = "0.23.0"
+ratatui = "0.24.0"
 
 [dev-dependencies]
 anyhow = "1.0.44"

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn render<B: Backend>(frame: &mut Frame<B>) -> Result<()> {
+fn render(frame: &mut Frame) -> Result<()> {
     let big_text = BigTextBuilder::default()
         .style(Style::new().blue())
         .lines(vec![

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -323,7 +323,7 @@ impl Tui {
         Ok(Self { terminal })
     }
 
-    fn draw(&mut self, frame: impl FnOnce(&mut Frame<CrosstermBackend<Stdout>>)) -> Result<()> {
+    fn draw(&mut self, frame: impl FnOnce(&mut Frame)) -> Result<()> {
         self.terminal.draw(frame).context("failed to draw frame")?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! use ratatui::prelude::*;
 //! use tui_big_text::BigTextBuilder;
 //!
-//! fn render<B: Backend>(frame: &mut Frame<B>) -> Result<()> {
+//! fn render(frame: &mut Frame) -> Result<()> {
 //!     let big_text = BigTextBuilder::default()
 //!         .style(Style::new().blue())
 //!         .lines(vec![


### PR DESCRIPTION
As Ratatui dropped the generic parameter for its Frame type, tui-big-text needs to be adapted.