### PR TITLE
readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install cargo-rdme
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-rdme
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-rdme
     - name: Check README.md is up-to-date
       run: cargo rdme --check
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,16 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install cargo-rdme
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-rdme
+    - name: Check README.md is up-to-date
+      run: cargo rdme --check
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ cargo add ratatui tui-big-text
 ## Example
 
 ```rust
-fn render<B: Backend>(frame: &mut Frame<B>) -> Result<()> {
+use anyhow::Result;
+use ratatui::prelude::*;
+use tui_big_text::BigTextBuilder;
+
+fn render(frame: &mut Frame) -> Result<()> {
     let big_text = BigTextBuilder::default()
         .style(Style::new().blue())
         .lines(vec![


### PR DESCRIPTION
- ci: add check for cargo-rdme to ensure readme is updated when lib.rs docs are
- docs: update readme with recent change for Frame no longer being generic

CI requires https://github.com/taiki-e/install-action/pull/265 to be merged to install-action