### PR TITLE
Update dependencies to ratatui 0.25.0 and itertools 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["cli", "console", "ratatui", "terminal", "tui"]
 [dependencies]
 derive_builder = "0.12.0"
 font8x8 = "0.3.1"
-itertools = "0.11.0"
+itertools = "0.12.0"
 ratatui = "0.24.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["cli", "console", "ratatui", "terminal", "tui"]
 derive_builder = "0.12.0"
 font8x8 = "0.3.1"
 itertools = "0.12.0"
-ratatui = "0.24.0"
+ratatui = "0.25.0"
 
 [dev-dependencies]
 anyhow = "1.0.44"


### PR DESCRIPTION
Ratatui had a few breaking changes in its last release 0.25.0.

While the application and tests did not need to be updated, I had to update the dependency in tui-big-text.
While I was doing that, I also took the opportunity to update itertools as well, as that got an update in the last month, too.

As we I noticed breaking changes in Ratatui, I would suggest to increment the version to at least 0.3, so that users on 0.2.x don't get problems when they are still on ratatui 0.24.0 and tui-big-text 0.2.x