### PR TITLE
fix(doc/check): builder initialization of BigTextBuilder in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub enum PixelSize {
 /// use ratatui::prelude::*;
 /// use tui_big_text::{BigTextBuilder, PixelSize};
 ///
-/// BigText::builder()
+/// BigTextBuilder::default()
 ///     .pixel_size(PixelSize::Full)
 ///     .style(Style::new().white())
 ///     .lines(vec![


### PR DESCRIPTION
Just a little fix for the code in documentation.