### PR TITLE
fix (src/big_text.rs): remove very annoying print statement

### DIFF
--- a/src/big_text.rs
+++ b/src/big_text.rs
@@ -93,10 +93,6 @@ fn layout(
     let width = 8_u16.div_ceil(step_x);
     let height = 8_u16.div_ceil(step_y);
 
-    if let PixelSize::Sextant = pixel_size {
-        println!("width: {},   height: {}", width, height);
-    }
-
     (area.top()..area.bottom())
         .step_by(height as usize)
         .map(move |y| {


### PR DESCRIPTION
I've used your library for my personal project and found out that extra symbols appear in terminal on each call to render function