### PR TITLE
feat: add alignment support for BigText

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,24 @@ pixel of the 8x8 font. It has six variants:
 - `ThirdHeight` - Each pixel is represented by a third of the height of a character cell.
 - `Sextant` - Each pixel is represented by a sixth of a character cell.
 
-<details><summary>Pixel Size Example</summary>
+```rust
+BigText::builder().pixel_size(PixelSize::Full);
+BigText::builder().pixel_size(PixelSize::HalfHeight);
+BigText::builder().pixel_size(PixelSize::Quadrant);
+```
 
 ![Pixel Size](https://vhs.charm.sh/vhs-2nLycKO16vHzqg3TxDNvq4.gif)
 
-</details>
+Text can be aligned to the Left / Right / Center using the `alignment` method.
+
+```rust
+use ratatui::layout::Alignment;
+BigText::builder().alignment(Alignment::Left);
+BigText::builder().alignment(Alignment::Right);
+BigText::builder().alignment(Alignment::Center);
+```
+
+![Alignment Example](https://vhs.charm.sh/vhs-1Yyr7BJ5vfmOmjYNywCNH3.gif)
 
 [tui-big-text]: https://crates.io/crates/tui-big-text
 [Ratatui]: https://crates.io/crates/ratatui

--- a/examples/alignment.rs
+++ b/examples/alignment.rs
@@ -1,0 +1,52 @@
+use std::{io::stdout, thread::sleep, time::Duration};
+
+use anyhow::Result;
+use crossterm::{
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use ratatui::prelude::*;
+use tui_big_text::{BigText, PixelSize};
+
+fn main() -> Result<()> {
+    stdout().execute(EnterAlternateScreen)?;
+    enable_raw_mode()?;
+    let backend = CrosstermBackend::new(stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+    terminal.draw(|frame| render(frame).expect("failed to render"))?;
+    sleep(Duration::from_secs(5));
+    terminal.clear()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    disable_raw_mode()?;
+    Ok(())
+}
+
+fn render(frame: &mut Frame) -> Result<()> {
+    let left = BigText::builder()
+        .pixel_size(PixelSize::Quadrant)
+        .alignment(Alignment::Left)
+        .lines(vec!["Left".white().into()])
+        .build()?;
+
+    let right = BigText::builder()
+        .pixel_size(PixelSize::Quadrant)
+        .alignment(Alignment::Right)
+        .lines(vec!["Right".green().into()])
+        .build()?;
+
+    let centered = BigText::builder()
+        .pixel_size(PixelSize::Quadrant)
+        .alignment(Alignment::Center)
+        .lines(vec!["Centered".red().into()])
+        .build()?;
+
+    use Constraint::*;
+    let [top, middle, bottom] = Layout::vertical([Length(4); 3]).areas(frame.size());
+
+    frame.render_widget(left, top);
+    frame.render_widget(right, middle);
+    frame.render_widget(centered, bottom);
+
+    Ok(())
+}

--- a/examples/alignment.tape
+++ b/examples/alignment.tape
@@ -1,0 +1,12 @@
+# VHS Tape (see https://github.com/charmbracelet/vhs)
+Output "target/alignment.gif"
+Set Theme "Aardvark Blue"
+Set Width 800
+Set Height 430
+Hide
+Type@0 "cargo run --example alignment --quiet"
+Enter
+Sleep 2s
+Show
+Screenshot "target/alignment.png"
+Sleep 1s

--- a/src/big_text.rs
+++ b/src/big_text.rs
@@ -896,4 +896,65 @@ mod tests {
         assert_buffer_eq!(buf, expected);
         Ok(())
     }
+
+    #[test]
+    fn render_alignment_left() -> Result<()> {
+        let big_text = BigText::builder()
+            .pixel_size(PixelSize::Quadrant)
+            .lines(vec![Line::from("Left")])
+            .alignment(Alignment::Left)
+            .build()?;
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 4));
+        big_text.render(buf.area, &mut buf);
+        let expected = Buffer::with_lines(vec![
+            "▜▛      ▗▛▙  ▟                          ",
+            "▐▌  ▟▀▙ ▟▙  ▝█▀                         ",
+            "▐▌▗▌█▀▀ ▐▌   █▗                         ",
+            "▀▀▀▘▝▀▘ ▀▀   ▝▘                         ",
+        ]);
+        assert_buffer_eq!(buf, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn render_alignment_right() -> Result<()> {
+        let big_text = BigText::builder()
+            .pixel_size(PixelSize::Quadrant)
+            .lines(vec![Line::from("Right")])
+            .alignment(Alignment::Right)
+            .build()?;
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 4));
+        big_text.render(buf.area, &mut buf);
+        let expected = Buffer::with_lines(vec![
+            "                    ▜▛▜▖ ▀      ▜▌   ▟  ",
+            "                    ▐▙▟▘▝█  ▟▀▟▘▐▙▜▖▝█▀ ",
+            "                    ▐▌▜▖ █  ▜▄█ ▐▌▐▌ █▗ ",
+            "                    ▀▘▝▘▝▀▘ ▄▄▛ ▀▘▝▘ ▝▘ ",
+        ]);
+        assert_buffer_eq!(buf, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn render_alignment_center() -> Result<()> {
+        let big_text = BigText::builder()
+            .pixel_size(PixelSize::Quadrant)
+            .lines(vec![Line::from("Centered"), Line::from("Lines")])
+            .alignment(Alignment::Center)
+            .build()?;
+        let mut buf = Buffer::empty(Rect::new(0, 0, 40, 8));
+        big_text.render(buf.area, &mut buf);
+        let expected = Buffer::with_lines(vec![
+            "    ▗▛▜▖         ▟               ▝█     ",
+            "    █   ▟▀▙ █▀▙ ▝█▀ ▟▀▙ ▜▟▜▖▟▀▙ ▗▄█     ",
+            "    ▜▖▗▖█▀▀ █ █  █▗ █▀▀ ▐▌▝▘█▀▀ █ █     ",
+            "     ▀▀ ▝▀▘ ▀ ▀  ▝▘ ▝▀▘ ▀▀  ▝▀▘ ▝▀▝▘    ",
+            "          ▜▛   ▀                        ",
+            "          ▐▌  ▝█  █▀▙ ▟▀▙ ▟▀▀           ",
+            "          ▐▌▗▌ █  █ █ █▀▀ ▝▀▙           ",
+            "          ▀▀▀▘▝▀▘ ▀ ▀ ▝▀▘ ▀▀▘           ",
+        ]);
+        assert_buffer_eq!(buf, expected);
+        Ok(())
+    }
 }

--- a/src/big_text.rs
+++ b/src/big_text.rs
@@ -96,6 +96,20 @@ impl Widget for BigText<'_> {
     }
 }
 
+fn get_alignment_offset<'a>(
+    area_width: u16,
+    letter_width: u16,
+    alignment: Alignment,
+    line: &'a Line<'a>,
+) -> u16 {
+    let big_line_width = line.width() as u16 * letter_width;
+    match alignment {
+        Alignment::Center => (area_width / 2).saturating_sub(big_line_width / 2),
+        Alignment::Right => area_width.saturating_sub(big_line_width),
+        Alignment::Left => 0,
+    }
+}
+
 /// Chunk the area into as many x*y cells as possible returned as a 2D iterator of `Rect`s
 /// representing the rows of cells. The size of each cell depends on given font size
 fn layout<'a>(
@@ -112,14 +126,7 @@ fn layout<'a>(
         .step_by(height as usize)
         .enumerate()
         .map(move |(i, y)| {
-            let offset = {
-                let big_line_width = lines[i].width() as u16 * width;
-                match alignment {
-                    Alignment::Center => (area.width / 2).saturating_sub(big_line_width / 2),
-                    Alignment::Right => area.width.saturating_sub(big_line_width),
-                    Alignment::Left => 0,
-                }
-            };
+            let offset = get_alignment_offset(area.width, width, alignment, &lines[i]);
             (area.left() + offset..area.right())
                 .step_by(width as usize)
                 .map(move |x| {

--- a/src/big_text.rs
+++ b/src/big_text.rs
@@ -96,20 +96,6 @@ impl Widget for BigText<'_> {
     }
 }
 
-fn get_alignment_offset<'a>(
-    area_width: u16,
-    letter_width: u16,
-    alignment: Alignment,
-    line: &'a Line<'a>,
-) -> u16 {
-    let big_line_width = line.width() as u16 * letter_width;
-    match alignment {
-        Alignment::Center => (area_width / 2).saturating_sub(big_line_width / 2),
-        Alignment::Right => area_width.saturating_sub(big_line_width),
-        Alignment::Left => 0,
-    }
-}
-
 /// Chunk the area into as many x*y cells as possible returned as a 2D iterator of `Rect`s
 /// representing the rows of cells. The size of each cell depends on given font size
 fn layout<'a>(
@@ -135,6 +121,20 @@ fn layout<'a>(
                     Rect::new(x, y, width, height)
                 })
         })
+}
+
+fn get_alignment_offset<'a>(
+    area_width: u16,
+    letter_width: u16,
+    alignment: Alignment,
+    line: &'a Line<'a>,
+) -> u16 {
+    let big_line_width = line.width() as u16 * letter_width;
+    match alignment {
+        Alignment::Center => (area_width / 2).saturating_sub(big_line_width / 2),
+        Alignment::Right => area_width.saturating_sub(big_line_width),
+        Alignment::Left => 0,
+    }
 }
 
 /// Render a single grapheme into a cell by looking up the corresponding 8x8 bitmap in the

--- a/src/big_text.rs
+++ b/src/big_text.rs
@@ -124,9 +124,9 @@ fn layout<'a>(
 
     (area.top()..area.bottom())
         .step_by(height as usize)
-        .enumerate()
-        .map(move |(i, y)| {
-            let offset = get_alignment_offset(area.width, width, alignment, &lines[i]);
+        .zip(lines.iter())
+        .map(move |(y, line)| {
+            let offset = get_alignment_offset(area.width, width, alignment, line);
             (area.left() + offset..area.right())
                 .step_by(width as usize)
                 .map(move |x| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,26 @@
 //! - `ThirdHeight` - Each pixel is represented by a third of the height of a character cell.
 //! - `Sextant` - Each pixel is represented by a sixth of a character cell.
 //!
-//! <details><summary>Pixel Size Example</summary>
+//! ```rust
+//! # use tui_big_text::*;
+//! BigText::builder().pixel_size(PixelSize::Full);
+//! BigText::builder().pixel_size(PixelSize::HalfHeight);
+//! BigText::builder().pixel_size(PixelSize::Quadrant);
+//! ```
 //!
 //! ![Pixel Size](https://vhs.charm.sh/vhs-2nLycKO16vHzqg3TxDNvq4.gif)
 //!
-//! </details>
+//! Text can be aligned to the Left / Right / Center using the `alignment` method.
+//!
+//! ```rust
+//! use ratatui::layout::Alignment;
+//! # use tui_big_text::*;
+//! BigText::builder().alignment(Alignment::Left);
+//! BigText::builder().alignment(Alignment::Right);
+//! BigText::builder().alignment(Alignment::Center);
+//! ```
+//!
+//! ![Alignment Example](https://vhs.charm.sh/vhs-1Yyr7BJ5vfmOmjYNywCNH3.gif)
 //!
 //! [tui-big-text]: https://crates.io/crates/tui-big-text
 //! [Ratatui]: https://crates.io/crates/ratatui


### PR DESCRIPTION
I added alignment field to BigText along with updating the layout function to create a layout that produces the given alignment. The default value of the alignment is Alignment::Left which will not change the current behavior.

Alignment::Center will center the text within the area

Alignment::Right will push the text to the far right of the area